### PR TITLE
Add frozen check on decreaseSupplyFromAddress

### DIFF
--- a/contracts/PaxosTokenV2.sol
+++ b/contracts/PaxosTokenV2.sol
@@ -371,6 +371,7 @@ contract PaxosTokenV2 is BaseStorage, EIP2612, EIP3009, AccessControlDefaultAdmi
      * @return success A boolean that indicates if the operation was successful
      */
     function decreaseSupplyFromAddress(uint256 value, address burnFromAddress) public virtual returns (bool success) {
+        require(!_isAddrFrozen(burnFromAddress), "burnFromAddress frozen");
         supplyControl.canBurnFromAddress(burnFromAddress, msg.sender);
         if (value > balances[burnFromAddress]) revert InsufficientFunds();
 

--- a/test/SupplyControlledTokenTest.js
+++ b/test/SupplyControlledTokenTest.js
@@ -271,6 +271,11 @@ describe('PaxosToken', function () {
           assert.equal(balance, finalAmount, 'supply controller balance matches');
         });
 
+        it('reverts if burnAddress is frozen', async function () {
+          await this.token.connect(this.assetProtectionRole).freeze(this.acc.address)
+          await expect(this.token.decreaseSupplyFromAddress(decreaseAmount, this.acc.address)).to.be.revertedWith("burnFromAddress frozen");
+        });
+
         it('emits a SupplyDecreased and a Transfer event', async function () {
           await expect(this.token.decreaseSupplyFromAddress(decreaseAmount, this.owner.address))
           .to.emit(this.token, "SupplyDecreased")


### PR DESCRIPTION
Adds an additional check to prevent decreasing the supply from a frozen address using `decreaseSupplyFromAddress`.

This should instead be done using `wipeFrozenAddress`