### PR TITLE
Domain Separator Patch

### DIFF
--- a/contracts/PaxosTokenV2.sol
+++ b/contracts/PaxosTokenV2.sol
@@ -122,6 +122,14 @@ contract PaxosTokenV2 is BaseStorage, EIP2612, EIP3009, AccessControlDefaultAdmi
     }
 
     /**
+     * @notice Initialize the domain separator for the contract.
+     * @dev This is public to allow for updates to the domain separator if the name is updated.
+     */
+    function initializeDomainSeparator() public {
+        _initializeDomainSeparator();
+    }
+
+    /**
      * @notice Returns the total supply of the token.
      * @return An uint256 representing the total supply of the token.
      */
@@ -484,7 +492,6 @@ contract PaxosTokenV2 is BaseStorage, EIP2612, EIP3009, AccessControlDefaultAdmi
         if (pastVersion < 1 && !initializedV1) {
             //Need this second condition since V1 could have used old upgrade pattern
             totalSupply_ = 0;
-            DOMAIN_SEPARATOR = EIP712._makeDomainSeparator(name(), "1");
             initializedV1 = true;
         }
     }
@@ -505,6 +512,14 @@ contract PaxosTokenV2 is BaseStorage, EIP2612, EIP3009, AccessControlDefaultAdmi
         __AccessControlDefaultAdminRules_init(initialDelay, initialOwner);
         _grantRole(PAUSE_ROLE, pauser);
         _grantRole(ASSET_PROTECTION_ROLE, assetProtector);
+        _initializeDomainSeparator();
+    }
+
+    /**
+     * @dev Private function to initialize the domain separator for the contract.
+     */
+    function _initializeDomainSeparator() private {
+        DOMAIN_SEPARATOR = EIP712._makeDomainSeparator(name(), "1");
     }
 
     /**

--- a/test/EIP712Test.js
+++ b/test/EIP712Test.js
@@ -1,0 +1,37 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("PaxosTokenV2 EIP712", function () {
+    const name = "PaxosToken USD";
+    const version = "1";
+
+    describe("Domain Separator Initialization", function () {
+        it("should initialize DOMAIN_SEPARATOR when calling initializeDomainSeparator()", async function () {
+            // Deploy without initializing
+            PaxosTokenV2 = await ethers.getContractFactory("PaxosTokenV2");
+            token = await PaxosTokenV2.deploy();
+            await token.waitForDeployment();
+            const tokenAddress = await token.getAddress();
+
+            // Call initializeDomainSeparator
+            await token.initializeDomainSeparator();
+
+            // Get the domain separator
+            const domainSeparator = await token.DOMAIN_SEPARATOR();
+
+            // Calculate expected domain separator
+            const domain = {
+                name: name,
+                version: version,
+                chainId: await ethers.provider.getNetwork().then(n => n.chainId),
+                verifyingContract: tokenAddress
+            };
+
+            // Create the domain separator hash using ethers.js v6
+            const domainSeparatorHash = ethers.TypedDataEncoder.hashDomain(domain);
+            
+            // Verify the domain separator matches
+            expect(domainSeparator).to.equal(domainSeparatorHash);
+        });
+    });
+});

--- a/test/UpgradeToV2Test.js
+++ b/test/UpgradeToV2Test.js
@@ -67,9 +67,9 @@ describe('UpgradeToV2', function () {
       assert.deepStrictEqual(this.bystanderApproval, await this.token.allowance(holder, bystander));
       assert.deepStrictEqual(this.frozenApproval, await this.token.allowance(holder, frozen)); // 0
       assert.strictEqual(this.bystanderFrozen, await this.token.isFrozen(bystander));
-      // assert.strictEqual(this.frozenFrozen, await this.token.isFrozen(frozen)); //This is actually different behavior
       assert.deepStrictEqual(this.totalSupply, await this.token.totalSupply());
       assert.strictEqual(this.paused, await this.token.paused());
+      assert.notStrictEqual(this.domainSeparator, await this.token.DOMAIN_SEPARATOR()); // Domain separator should be updated
     };
 
     // deploy the contracts
@@ -100,6 +100,7 @@ describe('UpgradeToV2', function () {
     this.frozenFrozen = await this.token.isFrozen(frozen);
     this.totalSupply = await this.token.totalSupply();
     this.paused = await this.token.paused();
+    this.domainSeparator = await this.token.DOMAIN_SEPARATOR(); // Store initial domain separator
   });
 
   it('can survive and integration test when not paused', async function () {


### PR DESCRIPTION
Implement domain separator initialization in PaxosTokenV2.  Previously the domain separator was not being initialized properly.  

The audit was done on a private repo commit which has been cherry picked here to the public version.  